### PR TITLE
DateInterval fix for ERN411

### DIFF
--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -623,7 +623,10 @@ class ErnParserController {
   protected function intervalFromIso86012004String(string $value): DateInterval
   {
       preg_match('/PT([0-9.,]*H)?([0-9.,]*M)?([0-9.,]*S)?/i', $value, $matches);
-      [, $hours, $minutes, $seconds] = $matches;
+
+      $hours = $matches[1] ?? null;
+      $minutes = $matches[2] ?? null;
+      $seconds = $matches[3] ?? null;
 
       $hours = (!empty($hours)) ? str_replace('H', '', $hours) : 0;
       $minutes = (!empty($minutes)) ? str_replace('M', '', $minutes) : 0;


### PR DESCRIPTION
**Problem:** Using array deconstructing (`[$val, $val2] = $array`) cannot account for indexes that do not exist. E.g. if the `$array` has only one element, deconstructing `$val2` will throw an error `Undefined array key 1`.

**Fix:** Stop using deconstructing and just extract values from the array in a more basic way, accounting for missing indexes.